### PR TITLE
Bump tauri-plugin-dialog 2.6.0

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-build = { version = "2.5.1", features = [] }
 drop_core = { path = "../core" }
 tauri = { version = "2.9.1", features = ["tray-icon"] }
 tauri-plugin-opener = "2.5.0"
-tauri-plugin-dialog = "2.4.0"
+tauri-plugin-dialog = "2.6.0"
 tauri-plugin-clipboard-manager = "2.3.0"
 dirs = "6.0.0"
 open = "5.3.2"


### PR DESCRIPTION
`main` CI fails because tauri-plugin-dialog versions differ in `Cargo.toml` and `package.json`. They should be the same. This PR assumes we have no backward compatibility issues with version 2.4.0. Therefore attempts to fix the CI to ensure artifacts are generated.

@kirillt @pushkarm029 could you take a look please.